### PR TITLE
Avoid PHP 8 warning when deleting avatar of an avatar-less user

### DIFF
--- a/event/banhammer_listener.php
+++ b/event/banhammer_listener.php
@@ -299,7 +299,7 @@ class banhammer_listener implements EventSubscriberInterface
 			$this->bh_del_privmsgs();
 		}
 
-		if ($this->request->variable('del_avatar', 0))
+		if ($this->request->variable('del_avatar', 0) && !empty($this->data['user_avatar']))
 		{
 			avatar_delete('user', $this->data, true);
 		}


### PR DESCRIPTION
### Problem

When an admin/moderator bans a user with the **Delete avatar** option enabled, and that user has **no avatar**, Ban Hammer triggers a PHP 8 warning and the post-ban redirect fails:

```
[phpBB Debug] PHP Warning: in file [ROOT]/includes/functions_user.php on line 2259: Uninitialized string offset 0
[phpBB Debug] PHP Warning: in file [ROOT]/includes/functions.php on line 1821: Cannot modify header information - headers already sent
```

The ban itself still commits (warnings do not halt execution), but the user is left on a debug-warning page instead of being redirected.

### Cause

In `event/banhammer_listener.php`, the avatar deletion runs unconditionally whenever the option is selected:

```php
if ($this->request->variable('del_avatar', 0))
{
    avatar_delete('user', $this->data, true);
}
```

For a user with no avatar, `avatar_delete()` calls core `get_avatar_filename()`, which does `$avatar_entry[0]` on an empty string. On PHP 8 that is a `Warning` (it was a silent `Notice` on PHP 7), and phpBB prints `E_WARNING` even in production, so the emitted output then breaks the redirect with "headers already sent".

### Fix

Only call `avatar_delete()` when the user actually has an avatar:

```php
if ($this->request->variable('del_avatar', 0) && !empty($this->data['user_avatar']))
{
    avatar_delete('user', $this->data, true);
}
```

One-line guard, no behaviour change for users who do have an avatar.
